### PR TITLE
Add BTC signal dashboard scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+API_KEY=
+OUTPUT_PATH=signals.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+signals.csv
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src ./src
+CMD ["python", "src/signal_dashboard.py"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# BTC Signal Dashboard
+
+This project pulls historical price and volume data for IBIT, MSTR and BTC,
+computes z-score based indicators and stores them in `signals.csv`. A simple
+Streamlit dashboard displays the latest snapshot.
+
+## Quick start
+
+```
+pip install -r requirements.txt
+python src/signal_dashboard.py
+streamlit run dashboard/app.py
+```
+
+Signals are written to `signals.csv`. Customize the output path via `.env` or
+the command line argument.

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,15 @@
+import pathlib
+import pandas as pd
+import streamlit as st
+
+DATA_FILE = pathlib.Path('signals.csv')
+
+st.title('BTC Signal Dashboard')
+
+if DATA_FILE.exists():
+    data = pd.read_csv(DATA_FILE, parse_dates=['Date'], index_col='Date')
+    latest = data.iloc[-1]
+    st.subheader('Latest snapshot')
+    st.dataframe(latest.unstack().T.style.background_gradient(axis=0))
+else:
+    st.warning('No signals.csv found. Run signal_dashboard.py first.')

--- a/docs/spec_v1.md
+++ b/docs/spec_v1.md
@@ -1,0 +1,159 @@
+Below is a self-contained specification your engineers can follow straight away.
+Feel free to prune or fine-tune, but it should give them everything they need for v1.
+
+---
+
+## 0 ― Executive summary (one-liner)
+
+> **Goal** : Nightly (or intra-day) pipeline that ingests BTC spot, IBIT ETF and MSTR equity market data, computes standardised z-score signals (price-distance, 30-day realised vol, volume surprise, optional IV-vs-RV), stores the results, and renders a lightweight dashboard that lets a trader click any row to see the full “trade signal card”.
+
+---
+
+## 1 ― Functional scope
+
+| #       | Capability                   | Detail                                                                                                                                                                                                                                                                                                                                    |        |        |          |
+| ------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------ | -------- |
+| **F-1** | **Automated data ingestion** | Pull **Adj Close** & **Volume** for IBIT, MSTR, BTC-USD once per run (default = end-of-day 16:15 ET).  Source = *yfinance* to start; swap to paid feed later without breaking interface.                                                                                                                                                  |        |        |          |
+| **F-2** | **Signal engine**            | For each asset, compute: <br>• `zPrice` (distance of log-price from 20-day SMA, normalised over 60 days) <br>• `zRV30` (annualised 30-day realised σ, normalised over 120 days) <br>• `zVol` (log-volume, 60-day z-score) <br>• `RV30` raw (for IV/RV spread later)<br>All calcs in **Python / pandas**, driven by `signal_dashboard.py`. |        |        |          |
+| **F-3** | **Persist signals**          | Append to a **signals** table (CSV in v1, migrate to TimescaleDB or DuckDB when scaling).  Schema = `trade_date                                                                                                                                                                                                                         | metric | ticker | value`. |
+| **F-4** | **Dashboard**                | Web UI (Streamlit is fine) that shows: <br>1. **Latest snapshot table** with z-scores for BTC, IBIT, MSTR (colour-graded cells).<br>2. Row click → right-hand “signal card” with: • metric values • quick narrative (“IBIT zPrice −2.4 σ with capitulation volume: mean-reversion long bias”) • link to raw CSV.                          |        |        |          |
+| **F-5** | **Scheduler & logging**      | Daily cron / Windows Task Scheduler entry.  Log fetch status, row count, min/max dates, errors.                                                                                                                                                                                                                                           |        |        |          |
+| **F-6** | **Config & secrets**         | Simple `.env` for API keys (e.g. paid data later).                                                                                                                                                                                                                                                                                        |        |        |          |
+| **F-7** | **Unit tests**               | Happy-path test for each indicator; regression test that yesterday’s run wrote one new date row.                                                                                                                                                                                                                                          |        |        |          |
+
+---
+
+## 2 ― Non-functional requirements
+
+| Topic             | Requirement                                                              |
+| ----------------- | ------------------------------------------------------------------------ |
+| **Latency**       | v1 EOD run must finish < 60 s on a dev laptop.                           |
+| **Refresh**       | Default frequency = daily; allow CLI flag `--intraday` for ad-hoc runs.  |
+| **Portability**   | Python 3.11, no OS-specific calls; Dockerfile supplied.                  |
+| **Observability** | Console + rolling log file; exit-code 0/1 for scheduler.                 |
+| **Security**      | No credentials in code; `.env` git-ignored; optional Vault later.        |
+| **Extensibility** | Signal class registry so adding `zIV_RV` or factor residuals is drop-in. |
+
+---
+
+## 3 ― System architecture (logical)
+
+```
+┌──────────────┌      fetch + calc      ┌──────────────┐
+│ Scheduler    │ ────────────────────► │  ETL/Calc │
+│ (cron/Task)  │                        └────────┐
+└──────────────┘                             │ writes CSV/DB
+                                             │
+                                        ┌─────────────────┐
+                                        │  Storage  │
+                                        └───────────────┘
+                                             │ read
+                                             │
+                                        ┌─────────────────┐
+                                        │ Dashboard │◄┌── user clicks
+                                        └───────────────┘
+```
+
+---
+
+## 4 ― Detailed component spec
+
+### 4.1  ETL/Calc module (`signal_dashboard.py`)
+
+| Section        | Key points                                                                            |
+| -------------- | ------------------------------------------------------------------------------------- |
+| **Fetch**      | `yfinance.download([...], start, progress=False)['Adj Close']` + `['Volume']`.        |
+| **Align**      | Forward-fill BTC to NYSE calendar; drop weekends for equities.                        |
+| **Indicators** | Functions `zscore(series, win)` & `realised_vol()`.  Constants at top for look-backs. |
+| **Outputs**    | 1) Write full history to `signals.csv` (over-write). 2) Print latest snapshot.        |
+| **CLI**        | `python signal_dashboard.py [outfile] [--start 2024-01-01]`.                          |
+| **Packaging**  | Place in `/src`.  Use `__main__` guard.                                               |
+
+### 4.2  Dashboard (suggested Streamlit MVP)
+
+| UI element      | Spec                                                                                                                           |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Table**       | `st.dataframe` of latest snapshot; conditional formatting (green = < −1, grey = -1 … +1, red = > +1).                          |
+| **Row click**   | `st.experimental_data_editor` or plain table + radio buttons → capture ticker.                                                 |
+| **Signal card** | Pull row dict → template string: <br>“**{ticker}**: zPrice {zp:+.2f}σ; zVol {zv:+.2f}σ; zRV30 {zrv:+.2f}σ. **Bias**: {logic}.” |
+| **Download**    | `st.download_button("CSV", data=open('signals.csv','rb'))`.                                                                    |
+| **Navigation**  | Left sidebar: date-range filter, refresh button (runs script).                                                                 |
+
+*Optional*: Chart modal showing last-90-days zPrice line.
+
+### 4.3  Storage
+
+* v1 = `signals.csv` in project root.
+* v1.1 = DuckDB file for SQL joins; minimal code change.
+* v2 = TimescaleDB/Postgres + SQLAlchemy models.
+
+### 4.4  Scheduler / Ops
+
+| Item        | Spec                                                                                                    |
+| ----------- | ------------------------------------------------------------------------------------------------------- |
+| **Unix**    | `0 16 * * 1-5 /path/to/venv/bin/python /app/src/signal_dashboard.py >> /var/log/btc_sig.log 2>&1`       |
+| **Windows** | Task Scheduler daily 16:15-16:20 ET.                                                                    |
+| **Docker**  | Multi-stage Dockerfile (`python:3.11-slim`, copy src, `CMD ["python","/app/src/signal_dashboard.py"]`). |
+
+---
+
+## 5 ― File & repo structure
+
+```
+/btc-signal-dashboard
+│
+├── src/
+│   ├── signal_dashboard.py
+├── dashboard/
+│   ├── app.py            # streamlit
+├── tests/
+│   ├── test_signals.py
+├── requirements.txt
+├── Dockerfile
+├── .env.example
+└── README.md
+```
+
+---
+
+## 6 ― Deliverables & timeline (suggested)
+
+| Week  | Deliverable                                                                        | Owner         |
+| ----- | ---------------------------------------------------------------------------------- | ------------- |
+| **1** | Repo scaffold, `requirements.txt`, data-ingest script fetching raw prices into CSV | Quant dev     |
+| **2** | Full indicator functions + unit tests (pytest)                                     | Quant dev     |
+| **3** | Streamlit dashboard MVP (static table, manual refresh)                             | Front-end dev |
+| **4** | Scheduler in lower-env, Docker container, logging                                  | DevOps        |
+| **5** | UAT: verify metrics vs external Bloomberg; hand-off to trading desk                | QA + Trader   |
+| **6** | Nice-to-have: IV-vs-RV column, param panel, chart modal                            | Quant dev     |
+
+---
+
+## 7 ― Acceptance criteria
+
+* **AC-1**: A fresh clone + `pip install -r requirements.txt` + `python signal_dashboard.py` creates `signals.csv` with ≥ 300 trading-day rows.
+* **AC-2**: For a known date (supply in test), zPrice, zRV30, zVol match benchmark Excel within ±1e-6.
+* **AC-3**: Dashboard loads in < 2 s, shows coloured table, clicking “IBIT” reveals narrative card.
+* **AC-4**: Cron job writes a new row the next trading day; log shows “Run OK”.
+* **AC-5**: No secrets checked into git; `.env` can override API keys and output path.
+
+---
+
+## 8 ― Future roadmap (out of v1 scope but easy next steps)
+
+1. **Add implied-vol data** via Cboe DataShop → compute `zIV_RV`.
+2. **REST API** (FastAPI) to serve `/latest` JSON for other tools.
+3. **Alerting**: Slack webhook when `|zPrice| > 2.5` **and** `zVol > 1.5`.
+4. **Live intraday micro-cycle**: 5-min candles for BTC vs MSTR with WebSockets.
+5. **ML ranking**: feed signals into Gradient Boosting model for %-return forecast.
+
+---
+
+### Hand-off checklist
+
+* [ ] Repo created with structure above
+* [ ] This spec committed as `/docs/spec_v1.md`
+* [ ] Trello / JIRA tickets mapped to Week column tasks
+* [ ] Dev environment instructions in README
+
+Once your team signs off on scope, they can start sprint 1 immediately.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+numpy
+yfinance
+streamlit
+pytest

--- a/src/signal_dashboard.py
+++ b/src/signal_dashboard.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Signal dashboard ETL script.
+
+This module downloads historical price and volume data for IBIT, MSTR and BTC,
+computes standardised z-score signals, and writes the full history to a CSV
+file. The latest snapshot is also printed to the console.
+
+Usage:
+    python signal_dashboard.py [outfile] [--start YYYY-MM-DD]
+"""
+from __future__ import annotations
+
+import sys
+import pathlib
+from datetime import date
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+import yfinance as yf
+
+# configurable look-back windows
+TREND_LEN = 20
+Z_NORM_PRICE_WINDOW = 60
+RV_WINDOW = 30
+Z_NORM_RV_WINDOW = 120
+Z_NORM_VOLUME_WINDOW = 60
+ANNUALISATION_DAYS = 252
+
+TICKERS = {
+    "IBIT": "IBIT",
+    "MSTR": "MSTR",
+    "BTC": "BTC-USD",
+}
+
+
+def zscore(series: pd.Series, window: int) -> pd.Series:
+    """Rolling z-score with population std-dev."""
+    r = series.rolling(window)
+    return (series - r.mean()) / r.std(ddof=0)
+
+
+def realised_vol(log_returns: pd.Series, span: int = RV_WINDOW,
+                 trading_days: int = ANNUALISATION_DAYS) -> pd.Series:
+    """Annualised realised volatility."""
+    return np.sqrt(trading_days) * log_returns.rolling(span).std(ddof=0)
+
+
+def fetch_data(start: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Download adjusted close and volume."""
+    price = yf.download(list(TICKERS.values()), start=start, progress=False)["Adj Close"]
+    volume = yf.download(list(TICKERS.values()), start=start, progress=False)["Volume"]
+    price = price.rename(columns={v: k for k, v in TICKERS.items()})
+    volume = volume.rename(columns={v: k for k, v in TICKERS.items()})
+    return price, volume
+
+
+def align_to_nyse(price: pd.DataFrame, volume: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Force BTC prints onto the NYSE calendar."""
+    btc_col = "BTC"
+    nyse_days = price.drop(columns=[btc_col]).index
+    price.loc[nyse_days, btc_col] = price[btc_col].loc[nyse_days].ffill()
+    volume.loc[nyse_days, btc_col] = volume[btc_col].loc[nyse_days].ffill()
+    return price.loc[nyse_days], volume.loc[nyse_days]
+
+
+def build_signals(price: pd.DataFrame, volume: pd.DataFrame) -> pd.DataFrame:
+    log_p = np.log(price)
+    ret = log_p.diff()
+
+    dist = log_p - log_p.rolling(TREND_LEN).mean()
+    z_price = dist.apply(zscore, window=Z_NORM_PRICE_WINDOW)
+
+    rv30 = ret.apply(realised_vol, span=RV_WINDOW)
+    z_rv30 = rv30.apply(zscore, window=Z_NORM_RV_WINDOW)
+
+    log_vol = np.log(volume.replace(0, np.nan))
+    z_vol = log_vol.apply(zscore, window=Z_NORM_VOLUME_WINDOW)
+
+    signals = pd.concat({
+        "zPrice": z_price,
+        "zRV30": z_rv30,
+        "zVol": z_vol,
+        "RV30": rv30,
+    }, axis=1).dropna()
+
+    return signals
+
+
+def main() -> None:
+    outfile = pathlib.Path("signals.csv")
+    start = "2024-01-01"
+
+    if len(sys.argv) > 1 and not sys.argv[1].startswith("--"):
+        outfile = pathlib.Path(sys.argv[1])
+        args = sys.argv[2:]
+    else:
+        args = sys.argv[1:]
+
+    for i, arg in enumerate(args):
+        if arg == "--start" and i + 1 < len(args):
+            start = args[i + 1]
+
+    price, volume = fetch_data(start)
+    price, volume = align_to_nyse(price, volume)
+    signals = build_signals(price, volume)
+
+    signals.to_csv(outfile, float_format="%.6f")
+    latest = signals.iloc[-1]
+
+    print(f"\n=== Latest z-scores (as of {latest.name.date()}) ===")
+    for col in ["IBIT", "MSTR", "BTC"]:
+        zp = latest["zPrice"][col]
+        zv = latest["zVol"].get(col, np.nan)
+        zrv = latest["zRV30"][col]
+        out = f"{col:<5s}  zPrice={zp:+6.2f}  zRV30={zrv:+6.2f}"
+        if not np.isnan(zv):
+            out += f"  zVol={zv:+6.2f}"
+        print(out)
+
+    print(f"\nSignals saved to: {outfile.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,30 @@
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+import pandas as pd
+import numpy as np
+
+from signal_dashboard import zscore, realised_vol, build_signals
+
+
+def test_zscore_simple():
+    s = pd.Series([1, 1, 1, 1, 1], dtype=float)
+    result = zscore(s, window=5)
+    assert pd.isna(result.iloc[-1])
+
+
+def test_realised_vol():
+    ret = pd.Series([0.0, 0.1, -0.1, 0.05], dtype=float)
+    rv = realised_vol(ret, span=2, trading_days=2)
+    assert len(rv.dropna()) > 0
+
+
+def test_build_signals():
+    dates = pd.date_range('2024-01-01', periods=65, freq='B')
+    price = pd.DataFrame({'IBIT': np.linspace(1, 65, 65),
+                          'MSTR': np.linspace(1, 65, 65),
+                          'BTC': np.linspace(1, 65, 65)}, index=dates)
+    volume = pd.DataFrame({'IBIT': 1, 'MSTR': 1, 'BTC': 1}, index=dates)
+    sig = build_signals(price, volume)
+    assert {'zPrice', 'zRV30', 'zVol', 'RV30'} <= set(sig.columns.get_level_values(0))


### PR DESCRIPTION
## Summary
- add project spec
- implement `signal_dashboard.py` for data ingestion and signal calculations
- provide basic Streamlit dashboard
- include unit tests for helper functions
- add project requirements and Dockerfile
- document quick start in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python src/signal_dashboard.py signals.csv` *(fails: CONNECT tunnel failed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_685049c3fd408328b6d632229cf626ac